### PR TITLE
:bug: Fix active bug by used of resolved property

### DIFF
--- a/src/u-router-item.vue/index.js
+++ b/src/u-router-item.vue/index.js
@@ -16,9 +16,10 @@ export default {
                 return console.warn('[proto-ui] Use `<u-router-item>` but cannot find vue router.');
 
             const current = this.$route;
-            const resolved = this.$router.resolve(this.to).resolved;
+            const location = this.$router.resolve(this.to).location;
+            const key = location.hasOwnProperty('name') ? 'name' : 'path';
 
-            return this.exact ? resolved.path === current.path : current.path.startsWith(resolved.path);
+            return this.exact ? location[key] === current[key] : current[key].startsWith(location[key]);
         },
     },
     methods: {


### PR DESCRIPTION
使用resolved或者route又带来了新的问题。如果传入的to，有指定redirect
属性，resolved对象内的name或path都会是redirect后的路由。导致一个问题：侧边栏的to指定xxx，redirect为xxx/list。如果路由变为xxx/edit(设置页)或xxx/detail(详情页)，侧边栏就无法选中了。

解决的方法：还是使用location属性，然后根据loaction对象内的`name`或`path`字段去判断是否选中。