### PR TITLE
:lipstick: u-region-select support custom data

### DIFF
--- a/src/components/u-region-select.vue/index.js
+++ b/src/components/u-region-select.vue/index.js
@@ -16,7 +16,11 @@ export const URegionSelect = {
         } },
     },
     created() {
-        import('./region.json').then((region) => this.currentData = region);
+        if (this.data) {
+            this.currentData = this.data;
+        } else {
+            import('./region.json').then((region) => this.currentData = region);
+        }
     },
 };
 


### PR DESCRIPTION
在 `UI` 库独立打包的情况下，后续二次打包时是无法被 `webpack` 感知到，所以将代码调整为在有外部透传数据的情况下，避免执行 `import('./region.json')` 逻辑。在二次打包的过程中，需要用户自行引用 `region.json` 的数据进行处理。

另外，此组件最大的意义，就是提供了一份 `省-市-区` 的数据，其他均使用 `u-cascade-select` 的逻辑。但这份数据需要有人进行维护，相关数据会有一定的变动。