### PR TITLE
:zap: improve e-watermark.vue experience

### DIFF
--- a/src/components/e-watermark.vue/index.html
+++ b/src/components/e-watermark.vue/index.html
@@ -1,5 +1,5 @@
 <div :class="$style.root">
     <canvas :class="$style.canvas" ref="canvas" :style="{ opacity }"></canvas>
     <canvas :class="$style.mark" ref="mark"
-        :width="markSize * 2 * Math.sqrt(3)" :height="markSize * 2"></canvas>
+        :width="markWidth" :height="markHeight"></canvas>
 </div>

--- a/src/components/e-watermark.vue/module.css
+++ b/src/components/e-watermark.vue/module.css
@@ -12,10 +12,6 @@
     position: absolute;
 }
 
-.canvas {
-    width: 100%;
-    height: 100%;
-}
 
 .mark {
     display: none;


### PR DESCRIPTION
+ 解决页面触发 `resize` 时 `canvas` 的抖动的问题
+ `resize` 做了节流处理，`250 ms` 表现效果还行，`100 ms` 效果比较差
+ 同时记录最大的 `width`、 `height`。当未达到最大 `width`、 `height` 时，`canvas` 不进行重绘，提升性能