### PR TITLE
:bug: Fix u-region-select with v-model render error

### DIFF
--- a/src/components/u-region-select.vue/README.md
+++ b/src/components/u-region-select.vue/README.md
@@ -12,6 +12,21 @@
 </u-linear-layout>
 ```
 
+```vue
+<template>
+    <u-region-select v-model="address"></u-region-select>
+</template>
+<script>
+export default {
+    data() {
+        return {
+            address: '',
+        };
+    },
+};
+</script>
+```
+
 ### Placeholder
 
 ``` html

--- a/src/components/u-region-select.vue/index.js
+++ b/src/components/u-region-select.vue/index.js
@@ -16,7 +16,7 @@ export const URegionSelect = {
         } },
     },
     created() {
-        !this.data && import('./region.json').then((region) => this.currentData = region);
+        !this.data && import('./region.json').then((region) => this.currentData = region.default);
     },
 };
 


### PR DESCRIPTION
`<u-region-select v-model="address"></u-region-select>`
`u-region-select` 配合 `v-model` 使用时，会报错。
原因是

1. 传参时数据结构如下

```
list = {
0: {},
1: {},
default: [
0: {},
1: {},
],
}
```

2.  含有 `v-model` 的情况下 `v-for` 会对 `default`  进行循环

老版本未出问题的原因是 新老 `webpack` 配置对 `import(*.json)` 的解析不一致

https://webpack.js.org/migrate/4/#import-and-commonjs
