### PR TITLE
Fix/u combo pagination.vue

### DIFF
--- a/src/components/u-combo-pagination.vue/i18n/en-US.json
+++ b/src/components/u-combo-pagination.vue/i18n/en-US.json
@@ -1,5 +1,6 @@
 {
     "pageSizeUnit": "items/page",
+    "pageUnit": "pages",
     "total": "total {total} items",
     "goto": "goto"
 }

--- a/src/components/u-combo-pagination.vue/i18n/zh-CN.json
+++ b/src/components/u-combo-pagination.vue/i18n/zh-CN.json
@@ -1,5 +1,6 @@
 {
     "pageSizeUnit": "条/页",
+    "pageUnit": "页",
     "total": "共 {total} 条",
     "goto": "前往"
 }

--- a/src/components/u-combo-pagination.vue/index.html
+++ b/src/components/u-combo-pagination.vue/index.html
@@ -14,5 +14,5 @@
             :min="1" :max="total" hide-buttons
             @change="$event.valid && onChange($event.value, $event.oldValue)">
         </u-number-input>
-    页</span>
+        {{ $t('pageUnit') }}</span>
 </u-linear-layout>

--- a/src/components/u-combo-pagination.vue/index.js
+++ b/src/components/u-combo-pagination.vue/index.js
@@ -1,17 +1,12 @@
 import i18n from './i18n';
-
+import UPagination from '../u-pagination.vue';
 export const UComboPagination = {
     name: 'u-combo-pagination',
     i18n,
     props: {
-        total: { type: Number, default: 11, validator: (value) => Number.isInteger(value) && value >= 0 },
-        page: { type: Number, default: 1, validator: (value) => Number.isInteger(value) && value > 0 },
+        ...UPagination.props,
         pageSize: { type: Number, default: 20 },
         pageSizeOptions: { type: Array, default() { return [10, 20, 50]; } },
-        side: { type: Number, default: 2, validator: (value) => Number.isInteger(value) && value > 0 },
-        around: { type: Number, default: 5, validator: (value) => Number.isInteger(value) && value > 0 && value % 2 === 1 },
-        readonly: { type: Boolean, default: false },
-        disabled: { type: Boolean, default: false },
         showTotal: { type: Boolean, default: false },
         showSizer: { type: Boolean, default: false },
         showJumper: { type: Boolean, default: false },

--- a/src/components/u-pagination.vue/index.js
+++ b/src/components/u-pagination.vue/index.js
@@ -17,9 +17,6 @@ export const UPagination = {
         page(page) {
             this.currentPage = page;
         },
-        currentPage(page, oldPage) {
-            this.$emit('change', { page, oldPage }, this);
-        },
     },
     computed: {
         pages() {
@@ -78,7 +75,7 @@ export const UPagination = {
                 return;
 
             this.currentPage = page;
-
+            this.$emit('change', { page, oldPage }, this);
             this.$emit('update:page', page, this);
             this.$emit('select', {
                 page,


### PR DESCRIPTION
+ `页` 未加入 `i18n`
+  `u-combo-pagination` 共享 `u-pagination` 的 `props` 配置
+ 使 `u-pagination` 与 `u-combo-pagination`  对 `currentPage` 的处理一致
