### PR TITLE
:bug: Fix e-ripple.vue cover child element

### DIFF
--- a/src/components/e-ripple.vue/module.css
+++ b/src/components/e-ripple.vue/module.css
@@ -10,6 +10,7 @@
     margin-top: -50px;
     transform: scale(0);
     cursor: pointer;
+    pointer-events: none;
 }
 
 .root[color="light"] {


### PR DESCRIPTION
`markdown` 的例子中，点击一次分页组件后，再次点击无响应

原因是点击动画完成后未将 `animated` 属性去除，导致该组件一直覆盖在其他子元素上方，造成其他元素无法被点击。

`animated` 属性去除的时间点不好把握，所以将 `css` 属性设置成 `pointer-events: none;`