### PR TITLE
:bug: RemoveChild when destroyed

### DIFF
--- a/src/components/u-drawer.vue/README.md
+++ b/src/components/u-drawer.vue/README.md
@@ -79,7 +79,7 @@ export default {
 | cancelButton | String | `'取消'` | 取消按钮文本，如果为空则不显示 |
 | size | String | `'normal'` | 抽屉的尺寸。可选值：`'small'`, `'normal'`, `'large'` |
 | static | Boolean | `false` | 是否嵌入页面显示 |
-| maskClosable | Boolean | `false` | 是否点击遮罩时关闭抽屉 |
+| maskClosable | Boolean | `true` | 是否点击遮罩时关闭抽屉 |
 
 ### Slots
 

--- a/src/components/u-modal.vue/index.js
+++ b/src/components/u-modal.vue/index.js
@@ -29,6 +29,10 @@ export const UModal = {
         if (!this.static)
             document.body.appendChild(this.$el);
     },
+    destroyed() {
+        if (!this.static)
+            document.body.removeChild(this.$el);
+    },
     methods: {
         open() {
             if (!this.$el)

--- a/src/components/u-toast.vue/README.md
+++ b/src/components/u-toast.vue/README.md
@@ -1,6 +1,14 @@
 # UToast 吐司提示
 
 ## 示例
+
+### 基本形式
+
+```html
+<u-button @click="$refs.toast2.show()">组件</u-button>
+<u-toast ref="toast2">2s</u-toast>
+```
+
 ### 快捷方式
 
 ``` vue

--- a/src/components/u-toast.vue/index.js
+++ b/src/components/u-toast.vue/index.js
@@ -17,6 +17,10 @@ export const UToast = {
         if (this.position !== 'static')
             document.body.appendChild(this.$el);
     },
+    destroyed() {
+        if (this.position !== 'static')
+            document.body.removeChild(this.$el);
+    },
     methods: {
         show(text, duration, color) {
             if (!this.$el)


### PR DESCRIPTION
`u-modal` `u-toast ` 在非快捷方式情况中均存在同一个问题，当显示 `modal` 的时候，接着点击浏览器的回退、前进按钮，此时 `modal` 依然停留在页面中，但是无法进行任何操作，只能刷新页面。

具体原因：点击浏览器的按钮时，组件已经被销毁了。但是 `document.body. appendChild` 的元素，无法被删除，需要手动删除 