### PR TITLE
:bug: Add clearTimeout when destroy

### DIFF
--- a/src/components/e-watermark.vue/index.js
+++ b/src/components/e-watermark.vue/index.js
@@ -17,7 +17,9 @@ export const EWatermark = {
     },
     watch: {
         text() {
-            setTimeout(() => {
+            this.clearTimeout();
+            this.timer = setTimeout(() => {
+                this.timer = undefined;
                 this.redrawMark();
                 this.redraw();
             }, 100);
@@ -40,9 +42,15 @@ export const EWatermark = {
         window.addEventListener('resize', this.redraw);
     },
     destroyed() {
+        this.clearTimeout();
         window.removeEventListener('resize', this.redraw);
     },
     methods: {
+        clearTimeout() {
+            if (this.timer) {
+                clearTimeout(this.timer);
+            }
+        },
         drawMark() {
             const markEl = this.$refs.mark;
             const width = markEl.width;

--- a/src/components/m-popper.vue/index.js
+++ b/src/components/m-popper.vue/index.js
@@ -114,6 +114,9 @@ export const MPopper = {
         this.destroyPopper();
         // 取消绑定事件
         this.offEvents.forEach((off) => off());
+        this.timers.forEach((timer) => {
+            clearTimeout(timer);
+        });
     },
     methods: {
         getOptions() {
@@ -188,6 +191,9 @@ export const MPopper = {
 
             this.triggers.push({ el, event });
 
+            // 收集 setTimeout
+            this.timers = this.timers || [];
+
             // 绑定事件
             this.followCursor && this.offEvents.push(ev.on(document, 'mousemove', (e) => this.updatePositionByCursor(e, el)));
 
@@ -204,14 +210,16 @@ export const MPopper = {
                 let timer;
                 this.offEvents.push(ev.on(el, 'mouseenter', (e) => {
                     timer = clearTimeout(timer);
-                    setTimeout(() => {
+                    this.timers[0] = setTimeout(() => {
                         this.open();
                         this.followCursor && this.$nextTick(() => this.updatePositionByCursor(e, el));
                     }, this.hoverDelay);
                 }));
                 this.offEvents.push(ev.on(document, 'mouseover', (e) => {
-                    if (this.currentOpened && !timer && !el.contains(e.target) && !popperEl.contains(e.target))
+                    if (this.currentOpened && !timer && !el.contains(e.target) && !popperEl.contains(e.target)) {
                         timer = setTimeout(() => this.close(), this.hideDelay);
+                        this.timers[1] = timer;
+                    }
                 }));
             } else if (event === 'double-click')
                 this.offEvents.push(ev.on(el, 'dblclick', (e) => {

--- a/src/components/u-carousel.vue/index.js
+++ b/src/components/u-carousel.vue/index.js
@@ -41,6 +41,9 @@ export const UCarousel = {
     mounted() {
         this.play();
     },
+    destroyed() {
+        clearTimeout(this.timer);
+    },
     methods: {
         prev() {
             clearTimeout(this.timer);

--- a/src/components/u-table-view.vue/index.js
+++ b/src/components/u-table-view.vue/index.js
@@ -187,8 +187,14 @@ export const UTableView = {
     },
     destroyed() {
         window.removeEventListener('resize', this.handleResize);
+        this.clearTimeout();
     },
     methods: {
+        clearTimeout() {
+            if (this.timer) {
+                clearTimeout(this.timer);
+            }
+        },
         processData(data) {
             const selectable = this.visibleColumnVMs.some((columnVM) => columnVM.type === 'radio');
             const checkable = this.visibleColumnVMs.some((columnVM) => columnVM.type === 'checkbox');
@@ -272,7 +278,9 @@ export const UTableView = {
         handleResize() {
             this.tableWidth = undefined;
             this.bodyHeight = undefined;
-            setTimeout(() => {
+            this.clearTimeout();
+            this.timer = setTimeout(() => {
+                this.timer = undefined;
                 let rootWidth = this.$el.offsetWidth;
                 if (!rootWidth) {
                     // 初始表格隐藏时，上面的值为0，需要特殊处理


### PR DESCRIPTION
清理组件设置的 `setTimeout`

+ `u-carousel.vue` 未清理导致方法不停地调用，形成调用链
+  `u-table-view.vue` 线上出现多次相关错误报警
+  `e-watermark.vue`  `m-popper.vue` 可以预知的是在一定情况下可能也会出错